### PR TITLE
Task11：各社員が持つスキルを閲覧できる画面を作成する

### DIFF
--- a/backend-ts/src/employee/Employee.ts
+++ b/backend-ts/src/employee/Employee.ts
@@ -1,9 +1,42 @@
 import * as t from 'io-ts';
 
+// 性別の型定義
+export const GenderT = t.union([
+    t.literal('男性'),
+    t.literal('女性'),
+    t.literal('その他')
+]);
+
+// 所属の型定義
+export const DepartmentT = t.union([
+    t.literal('A'),
+    t.literal('B'),
+    t.literal('C'),
+    t.literal('D')
+]);
+
+// スキル・希望の型定義
+export const SkillT = t.union([
+    t.literal('フロントエンド'),
+    t.literal('バックエンド'),
+    t.literal('クラウド'),
+    t.literal('デザイン'),
+    t.literal('PM')
+]);
+
 export const EmployeeT = t.type({
     id: t.string,
     name: t.string,
     age: t.number,
+    gender: GenderT,
+    department: DepartmentT,
+    skills: t.array(SkillT),
+    qualifications: t.array(t.string),
+    hireYear: t.number,
+    aspirations: t.array(SkillT),
 });
 
 export type Employee = t.TypeOf<typeof EmployeeT>;
+export type Gender = t.TypeOf<typeof GenderT>;
+export type Department = t.TypeOf<typeof DepartmentT>;
+export type Skill = t.TypeOf<typeof SkillT>;

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -6,9 +6,116 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
 
     constructor() {
         this.employees = new Map<string, Employee>();
-        this.employees.set("1", { id: "1", name: "Jane Doe", age: 22 });
-        this.employees.set("2", { id: "2", name: "John Smith", age: 28 });
-        this.employees.set("3", { id: "3", name: "山田 太郎", age: 27 });
+        this.employees.set("1", { 
+            id: "1", 
+            name: "Jane Doe", 
+            age: 22,
+            gender: "女性",
+            department: "A",
+            skills: ["フロントエンド", "デザイン"],
+            qualifications: ["Webデザイン検定"],
+            hireYear: 2022,
+            aspirations: ["PM", "デザイン"]
+        });
+        this.employees.set("2", { 
+            id: "2", 
+            name: "John Smith", 
+            age: 28,
+            gender: "男性",
+            department: "B",
+            skills: ["バックエンド", "クラウド"],
+            qualifications: ["AWS認定ソリューションアーキテクト"],
+            hireYear: 2019,
+            aspirations: ["PM", "クラウド"]
+        });
+        this.employees.set("3", { 
+            id: "3", 
+            name: "山田 太郎", 
+            age: 27,
+            gender: "男性",
+            department: "C",
+            skills: ["フロントエンド", "バックエンド"],
+            qualifications: ["応用情報技術者"],
+            hireYear: 2021,
+            aspirations: ["フロントエンド", "バックエンド"]
+        });
+        this.employees.set("4", { 
+            id: "4", 
+            name: "山田 花子", 
+            age: 27,
+            gender: "女性",
+            department: "D",
+            skills: ["デザイン", "PM"],
+            qualifications: ["Webデザイン検定"],
+            hireYear: 2020,
+            aspirations: ["PM"]
+        });
+        this.employees.set("5", { 
+            id: "5", 
+            name: "布施 悠", 
+            age: 27,
+            gender: "男性",
+            department: "A",
+            skills: ["クラウド", "バックエンド"],
+            qualifications: ["GCP認定"],
+            hireYear: 2023,
+            aspirations: ["クラウド", "バックエンド"]
+        });
+        this.employees.set("6", { 
+            id: "6", 
+            name: "藤井 大輝", 
+            age: 27,
+            gender: "男性",
+            department: "B",
+            skills: ["フロントエンド"],
+            qualifications: ["HTML5プロフェッショナル"],
+            hireYear: 2018,
+            aspirations: ["フロントエンド", "デザイン"]
+        });
+        this.employees.set("7", { 
+            id: "7", 
+            name: "小林 一郎", 
+            age: 27,
+            gender: "男性",
+            department: "C",
+            skills: ["PM", "デザイン"],
+            qualifications: ["PMP"],
+            hireYear: 2017,
+            aspirations: ["PM"]
+        });
+        this.employees.set("8", { 
+            id: "8", 
+            name: "中村 佑", 
+            age: 27,
+            gender: "男性",
+            department: "D",
+            skills: ["バックエンド", "クラウド"],
+            qualifications: ["データベーススペシャリスト"],
+            hireYear: 2020,
+            aspirations: ["クラウド"]
+        });
+        this.employees.set("9", { 
+            id: "9", 
+            name: "垣谷 大輝", 
+            age: 27,
+            gender: "男性",
+            department: "A",
+            skills: ["フロントエンド", "バックエンド", "デザイン"],
+            qualifications: ["基本情報技術者"],
+            hireYear: 2022,
+            aspirations: ["フロントエンド", "バックエンド", "デザイン"]
+        });
+        this.employees.set("10", { 
+            id: "10",
+            name: "石田 樹",
+            age: 27,
+            gender: "男性",
+            department: "B",
+            skills: ["クラウド", "PM"],
+            qualifications: ["Azure認定"],
+            hireYear: 2016,
+            aspirations: ["PM", "クラウド"]
+        });
     }
 
     async getEmployee(id: string): Promise<Employee | undefined> {

--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -1,11 +1,12 @@
 import PersonIcon from "@mui/icons-material/Person";
-import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
+import { Avatar, Box, Paper, Tab, Tabs, Typography, Chip } from "@mui/material";
 import { Employee } from "../models/Employee";
 import { useCallback, useState } from "react";
 
 const tabPanelValue = {
   basicInfo: "基本情報",
-  others: "その他",
+  skills: "スキル・資格",
+  aspirations: "希望分野",
 };
 
 type TabPanelValue = keyof typeof tabPanelValue;
@@ -67,20 +68,56 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
         <Box sx={{ borderBottom: 1, borderColor: "divider", width: "100%" }}>
           <Tabs value={selectedTabValue} onChange={handleTabValueChange}>
             <Tab label={tabPanelValue.basicInfo} value={"basicInfo"} />
-            <Tab label={tabPanelValue.others} value={"others"} />
+            <Tab label={tabPanelValue.skills} value={"skills"} />
+            <Tab label={tabPanelValue.aspirations} value={"aspirations"} />
           </Tabs>
         </Box>
 
         <TabContent value={"basicInfo"} selectedValue={selectedTabValue}>
-          <Box p={2} display="flex" flexDirection="column" gap={1}>
-            <Typography variant="h6">基本情報</Typography>
-            <Typography>年齢：{employee.age}歳</Typography>
+          <Box p={2} display="flex" flexDirection="column" gap={2}>
+            <Box display="flex" flexDirection="column" gap={1}>
+              <Typography><strong>名前：</strong>{employee.name}</Typography>
+              <Typography><strong>年齢：</strong>{employee.age}歳</Typography>
+              <Typography><strong>性別：</strong>{employee.gender}</Typography>
+              <Typography><strong>所属：</strong>{employee.department}</Typography>
+              <Typography><strong>入社年数：</strong>{new Date().getFullYear() - employee.hireYear}年</Typography>
+            </Box>
           </Box>
         </TabContent>
 
-        <TabContent value={"others"} selectedValue={selectedTabValue}>
-          <Box p={2} display="flex" flexDirection="column" gap={1}>
-            <Typography variant="h6">その他</Typography>
+        <TabContent value={"skills"} selectedValue={selectedTabValue}>
+          <Box p={2} display="flex" flexDirection="column" gap={2}>
+            <Box display="flex" flexDirection="column" gap={2}>
+              <Box>
+                <Typography variant="subtitle1" gutterBottom><strong>スキル：</strong></Typography>
+                <Box display="flex" flexWrap="wrap" gap={1}>
+                  {employee.skills.map((skill, index) => (
+                    <Chip key={index} label={skill} color="primary" variant="outlined" />
+                  ))}
+                </Box>
+              </Box>
+              <Box>
+                <Typography variant="subtitle1" gutterBottom><strong>資格：</strong></Typography>
+                <Box display="flex" flexWrap="wrap" gap={1}>
+                  {employee.qualifications.map((qualification, index) => (
+                    <Chip key={index} label={qualification} color="secondary" variant="outlined" />
+                  ))}
+                </Box>
+              </Box>
+            </Box>
+          </Box>
+        </TabContent>
+
+        <TabContent value={"aspirations"} selectedValue={selectedTabValue}>
+          <Box p={2} display="flex" flexDirection="column" gap={2}>
+            <Box>
+              <Typography variant="subtitle1" gutterBottom><strong>希望分野：</strong></Typography>
+              <Box display="flex" flexWrap="wrap" gap={1}>
+                {employee.aspirations.map((aspiration, index) => (
+                  <Chip key={index} label={aspiration} color="success" variant="outlined" />
+                ))}
+              </Box>
+            </Box>
           </Box>
         </TabContent>
       </Box>

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -1,6 +1,6 @@
 import PersonIcon from "@mui/icons-material/Person";
 
-import { Avatar, Box, Card, CardContent, Typography } from "@mui/material";
+import { Avatar, Box, Card, CardContent, Typography, Chip } from "@mui/material";
 import { Employee } from "../models/Employee";
 import Link from "next/link";
 
@@ -24,12 +24,44 @@ export function EmployeeListItem(prop: EmployeeListItemProps) {
         }}
       >
         <CardContent>
-          <Box display="flex" flexDirection="row" alignItems="center" gap={2}>
+          <Box display="flex" flexDirection="row" alignItems="flex-start" gap={2}>
             <Avatar sx={{ width: 48, height: 48 }}>
               <PersonIcon sx={{ fontSize: 48 }} />
             </Avatar>
-            <Box display="flex" flexDirection="column">
-              <Typography>{employee.name}</Typography>
+            <Box display="flex" flexDirection="column" gap={1} flex={1}>
+              <Box display="flex" alignItems="center" gap={1}>
+                <Typography variant="h6">{employee.name}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {employee.age}歳
+                </Typography>
+              </Box>
+              <Box display="flex" alignItems="center" gap={1}>
+                <Typography variant="body2" color="text.secondary">
+                  所属: {employee.department}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  入社{new Date().getFullYear() - employee.hireYear}年
+                </Typography>
+              </Box>
+              <Box display="flex" flexWrap="wrap" gap={0.5}>
+                {employee.skills.slice(0, 3).map((skill, index) => (
+                  <Chip 
+                    key={index} 
+                    label={skill} 
+                    size="small" 
+                    color="primary" 
+                    variant="outlined" 
+                  />
+                ))}
+                {employee.skills.length > 3 && (
+                  <Chip 
+                    label={`+${employee.skills.length - 3}`} 
+                    size="small" 
+                    color="default" 
+                    variant="outlined" 
+                  />
+                )}
+              </Box>
             </Box>
           </Box>
         </CardContent>

--- a/frontend/src/models/Employee.ts
+++ b/frontend/src/models/Employee.ts
@@ -1,9 +1,42 @@
 import * as t from "io-ts";
 
+// 性別の型定義
+export const GenderT = t.union([
+    t.literal('男性'),
+    t.literal('女性'),
+    t.literal('その他')
+]);
+
+// 所属の型定義
+export const DepartmentT = t.union([
+    t.literal('A'),
+    t.literal('B'),
+    t.literal('C'),
+    t.literal('D')
+]);
+
+// スキル・希望の型定義
+export const SkillT = t.union([
+    t.literal('フロントエンド'),
+    t.literal('バックエンド'),
+    t.literal('クラウド'),
+    t.literal('デザイン'),
+    t.literal('PM')
+]);
+
 export const EmployeeT = t.type({
   id: t.string,
   name: t.string,
   age: t.number,
+  gender: GenderT,
+  department: DepartmentT,
+  skills: t.array(SkillT),
+  qualifications: t.array(t.string),
+  hireYear: t.number,
+  aspirations: t.array(SkillT),
 });
 
 export type Employee = t.TypeOf<typeof EmployeeT>;
+export type Gender = t.TypeOf<typeof GenderT>;
+export type Department = t.TypeOf<typeof DepartmentT>;
+export type Skill = t.TypeOf<typeof SkillT>;


### PR DESCRIPTION
**概要**
従業員データモデルを拡張し、基本情報（性別、所属、スキル、資格、入社年、希望分野）を含む包括的な人材管理システムを実装しました。

**実装内容**

1. Employeeモデルの拡張
- 性別（男性、女性、その他）
- 所属（A、B、C、D）
- スキル（フロントエンド、バックエンド、クラウド、デザイン、PM）
- 資格（文字列配列）
- 入社年（数値）
- 希望分野（スキルと同じ選択肢）

2. 実行時型チェックの実装
- io-tsを使用した型安全なデータ検証
- コンパイル時と実行時の型一貫性を保証

3. フロントエンドUIの改善
- EmployeeDetails: タブ形式で基本情報、スキル・資格、希望分野を表示
- EmployeeListItem: カード形式で年齢、所属、スキル、入社年数を表示
- 入社年から現在の年数を動的に計算

4. サンプルデータの充実
- 10人の従業員データに現実的な情報を設定
- 各従業員のスキル、資格、希望分野を適切に設定