### PR TITLE
task2 ウィンドウタイトルへのページ名の表示

### DIFF
--- a/frontend/lib/metadata.ts
+++ b/frontend/lib/metadata.ts
@@ -1,0 +1,11 @@
+export const pageMetadata = {
+  home: {
+    title: "Talenza - 社員検索",
+    description: "社員を検索",
+  },
+  profile: {
+    title: "Talenza - 社員詳細",
+    description: "社員の詳細情報",
+  },
+  employeeDetailTitleTemplate: "Talenza - 社員詳細 | {employeeName}",
+};

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,12 @@
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
+import { Metadata } from "next";
+import { pageMetadata } from "../../lib/metadata";
+
+export const metadata: Metadata = {
+  title: pageMetadata.home.title,
+  description: pageMetadata.home.description,
+};
 
 export default function Home() {
   return (

--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -1,7 +1,8 @@
 import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { pageMetadata } from "../../lib/metadata";
 
 const tabPanelValue = {
   basicInfo: "基本情報",
@@ -43,6 +44,14 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
     },
     []
   );
+
+  useEffect(() => {
+    const title = pageMetadata.employeeDetailTitleTemplate.replace(
+        "{employeeName}",
+        employee.name
+      );
+    document.title = title;
+  }, [employee.name]);
 
   return (
     <Paper sx={{ p: 2 }}>


### PR DESCRIPTION
概要
- ユーザーが現在閲覧しているページ名等の情報をウィンドウタイトルに反映する機能の追加

変更内容
- `/lib/metadata.ts`を追加し、ページごとのタイトルテンプレートを一元管理
- 上記を各ページに読み込ませ反映
- 社員詳細ページには動的に社員名を含むタイトルを生成するため、useEffrctを使い、社員情報取得後にタイトルの設定を行う