### PR TITLE
Task4: 詳細画面への「検索画面に戻る」ボタン実装

### DIFF
--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -1,7 +1,9 @@
 import PersonIcon from "@mui/icons-material/Person";
-import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
+import { Avatar, Box, Paper, Tab, Tabs, Typography, Button } from "@mui/material";
 import { Employee } from "../models/Employee";
 import { useCallback, useState } from "react";
+import Link from 'next/link';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 const tabPanelValue = {
   basicInfo: "基本情報",
@@ -46,6 +48,14 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
 
   return (
     <Paper sx={{ p: 2 }}>
+      <Button
+        component={Link}
+        href="/"
+        startIcon={<ArrowBackIcon />}
+        sx={{ mb: 2 }} 
+      >
+        検索画面に戻る
+    </Button>
       <Box
         display={"flex"}
         flexDirection="column"


### PR DESCRIPTION
## 概要
詳細画面から検索画面に戻る機能を実装しました

## 詳細
詳細画面の左上に検索画面へ戻るためのリンクを配置しました
アイコンや色を工夫して、リンクが見やすいようにしました

## 生成AIの利用について
アイコンや色の部分は生成AIを利用しました。会話履歴は以下のようになっています

<details>
<summary>会話履歴</summary>

- 入力：下記のようなホーム画面に戻るリンクをnext.jsで書いたのですが、色やアイコンなどをつけて、ユーザーが見やすいように工夫してください
```javascript
<Box mb={2}>
  <Link href="/">＜ 検索画面に戻る</Link>
</Box>
```

- 出力されたコード
```javascript
<Button
    component={Link}
    href="/"
    startIcon={<ArrowBackIcon />}
    sx={{ mb: 2 }} 
  >
    検索画面に戻る
</Button>
