### PR TITLE
task3 グローバルヘッダへのページ名の表示

### DIFF
--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -1,15 +1,26 @@
+"use client";
+// GlobalContainer.tsx
 import { Container } from "@mui/material";
 import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
+import { useEffect, useState } from "react";
 
 export function GlobalContainer({ children }: { children?: React.ReactNode }) {
+  const [title, setTitle] = useState("Talenza");
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setTitle(document.title);
+    }
+  }, []);
+
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <header>
-        <GlobalHeader title={"Talenza"} />
+        <GlobalHeader title={title} />
       </header>
 
       <VerticalSpacer height={32} />


### PR DESCRIPTION
概要
各ページに設定しているタイトルをヘッダーにも表示できるように変更。GlobalContainerをクライアントコンポーネントとして明示し、クライアントサイドでタイトルを取得しGlobalHeaderに渡すようにしています。

主な変更点
- GlobalContainer.tsx に "use client" を追加
- useState / useEffect を使ってクライアントサイドで document.title を取得
- 取得したタイトルを GlobalHeader に props として渡す実装を追加