### PR TITLE
task5 社員の追加機能

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabase.ts
+++ b/backend-ts/src/employee/EmployeeDatabase.ts
@@ -3,4 +3,5 @@ import { Employee } from "./Employee";
 export interface EmployeeDatabase {
     getEmployee(id: string): Promise<Employee | undefined>
     getEmployees(filterText: string): Promise<Employee[]>
+    addEmployee(employee: Employee): Promise<void>;
 }

--- a/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
@@ -1,4 +1,4 @@
-import { DynamoDBClient, GetItemCommand, GetItemCommandInput, ScanCommand, ScanCommandInput } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, GetItemCommand, GetItemCommandInput, ScanCommand, ScanCommandInput, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { isLeft } from "fp-ts/Either";
 import { EmployeeDatabase } from "./EmployeeDatabase";
 import { Employee, EmployeeT } from "./Employee";
@@ -63,6 +63,24 @@ export class EmployeeDatabaseDynamoDB implements EmployeeDatabase {
                     return [decoded.right];
                 }
             });
+    }
+
+    async addEmployee(employee: Employee): Promise<void> {
+        const input = {
+            TableName: this.tableName,
+            Item: {
+                id: { S: employee.id },
+                name: { S: employee.name },
+                age: { N: employee.age.toString() },
+                gender: { S: employee.gender },
+                department: { S: employee.department },
+                skills: { SS: employee.skills },
+                qualifications: { SS: employee.qualifications },
+                hireYear: { N: employee.hireYear.toString() },
+                aspirations: { SS: employee.aspirations },
+            },
+        };
+        await this.client.send(new PutItemCommand(input));
     }
 }
 

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -129,4 +129,8 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
         }
         return employees.filter(employee => employee.name.toLowerCase().includes(filterText));
     }
+
+    async addEmployee(employee: Employee): Promise<void> {
+        this.employees.set(employee.id, employee);
+    }
 }

--- a/frontend/src/app/employee/add/page.tsx
+++ b/frontend/src/app/employee/add/page.tsx
@@ -1,0 +1,11 @@
+// app/employee/add/page.tsx
+import { GlobalContainer } from "@/components/GlobalContainer";
+import { EmployeeAddForm } from "@/components/EmployeeForm";
+
+export default function AddEmployeePage() {
+  return (
+    <GlobalContainer>
+      <EmployeeAddForm />
+    </GlobalContainer>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@ import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
 import { Metadata } from "next";
 import { pageMetadata } from "../../lib/metadata";
+import AddEmployeeButton from "@/components/AddEmployeeButton";
 
 export const metadata: Metadata = {
   title: pageMetadata.home.title,
@@ -11,6 +12,7 @@ export const metadata: Metadata = {
 export default function Home() {
   return (
     <GlobalContainer>
+      <AddEmployeeButton />
       <SearchEmployees />
     </GlobalContainer>
   );

--- a/frontend/src/components/AddEmployeeButton.tsx
+++ b/frontend/src/components/AddEmployeeButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import { useRouter } from "next/navigation";
+
+const AddEmployeeButton = () => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/employee/add");
+  };
+
+  return (
+    <Button
+      variant="contained"
+      color="primary"
+      startIcon={<AddIcon />}
+      onClick={handleClick}
+    >
+      社員追加
+    </Button>
+  );
+};
+
+export default AddEmployeeButton;

--- a/frontend/src/components/EmployeeForm.tsx
+++ b/frontend/src/components/EmployeeForm.tsx
@@ -1,0 +1,134 @@
+// frontend/components/EmployeeAddForm.tsx
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Gender, Department, Skill, Employee } from "../models/Employee";
+import { Button, TextField, Select, MenuItem, InputLabel, FormControl, Checkbox, ListItemText, OutlinedInput, Box } from "@mui/material";
+import Link from "next/link";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+
+const genders: Gender[] = ["男性", "女性", "その他"];
+const departments: Department[] = ["A", "B", "C", "D"];
+const skills: Skill[] = ["フロントエンド", "バックエンド", "クラウド", "デザイン", "PM"];
+
+export function EmployeeAddForm() {
+  const [name, setName] = useState("");
+  const [age, setAge] = useState<number | "">("");
+  const [gender, setGender] = useState<Gender>("男性");
+  const [department, setDepartment] = useState<Department>("A");
+  const [skillsSelected, setSkillsSelected] = useState<Skill[]>([]);
+  const [qualifications, setQualifications] = useState<string>("");
+  const [hireYear, setHireYear] = useState<number | "">("");
+  const [aspirationsSelected, setAspirationsSelected] = useState<Skill[]>([]);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name || !age || !hireYear) {
+      alert("名前・年齢・入社年は必須です");
+      return;
+    }
+
+    const employee: Omit<Employee, "id"> = {
+      name,
+      age: Number(age),
+      gender,
+      department,
+      skills: skillsSelected,
+      qualifications: qualifications.split(",").map(q => q.trim()).filter(Boolean),
+      hireYear: Number(hireYear),
+      aspirations: aspirationsSelected,
+    };
+
+    const res = await fetch("/employee", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(employee),
+    });
+
+    if (!res.ok) {
+      alert("登録に失敗しました" );
+      return;
+    }
+
+    alert("登録成功！");
+    router.back();
+  };
+
+  return (
+    <>
+      <Button
+        component={Link}
+        href="/"
+        startIcon={<ArrowBackIcon />}
+        sx={{ mb: 2 }}
+      >
+        検索画面に戻る
+      </Button>
+      <Box component="form" onSubmit={handleSubmit} sx={{ maxWidth: 500, mx: "auto", display: "flex", flexDirection: "column", gap: 2 }}>
+      <TextField label="名前" value={name} onChange={e => setName(e.target.value)} required />
+      <TextField label="年齢" type="number" value={age} onChange={e => setAge(e.target.value === "" ? "" : Number(e.target.value))} required />
+      <FormControl>
+        <InputLabel>性別</InputLabel>
+        <Select value={gender} onChange={e => setGender(e.target.value as Gender)} label="性別">
+          {genders.map(g => <MenuItem key={g} value={g}>{g}</MenuItem>)}
+        </Select>
+      </FormControl>
+      <FormControl>
+        <InputLabel>所属</InputLabel>
+        <Select value={department} onChange={e => setDepartment(e.target.value as Department)} label="所属">
+          {departments.map(d => <MenuItem key={d} value={d}>{d}</MenuItem>)}
+        </Select>
+      </FormControl>
+      <FormControl>
+        <InputLabel>スキル</InputLabel>
+        <Select
+          multiple
+          value={skillsSelected}
+          onChange={e => setSkillsSelected(typeof e.target.value === "string" ? e.target.value.split(",") as Skill[] : e.target.value)}
+          input={<OutlinedInput label="スキル" />}
+          renderValue={(selected) => (selected as string[]).join(", ")}
+        >
+          {skills.map(skill => (
+            <MenuItem key={skill} value={skill}>
+              <Checkbox checked={skillsSelected.indexOf(skill) > -1} />
+              <ListItemText primary={skill} />
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <TextField
+        label="資格（カンマ区切り）"
+        value={qualifications}
+        onChange={e => setQualifications(e.target.value)}
+      />
+      <TextField
+        label="入社年"
+        type="number"
+        value={hireYear}
+        onChange={e => setHireYear(e.target.value === "" ? "" : Number(e.target.value))}
+        required
+      />
+      <FormControl>
+        <InputLabel>希望</InputLabel>
+        <Select
+          multiple
+          value={aspirationsSelected}
+          onChange={e => setAspirationsSelected(typeof e.target.value === "string" ? e.target.value.split(",") as Skill[] : e.target.value)}
+          input={<OutlinedInput label="希望" />}
+          renderValue={(selected) => (selected as string[]).join(", ")}
+        >
+          {skills.map(skill => (
+            <MenuItem key={skill} value={skill}>
+              <Checkbox checked={aspirationsSelected.indexOf(skill) > -1} />
+              <ListItemText primary={skill} />
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+        <Button type="submit" variant="contained" color="primary">社員追加</Button>
+      </Box>
+    </>
+  );
+}


### PR DESCRIPTION
社員追加機能を実装し、従業員データベースに新しい従業員を追加できるようにしました。フロントエンドに従業員追加フォームとボタンを追加しました。

変更点
employee/add/page.tsxを追加し、社員の登録フォームを実装
EmployeeForm.tsx、AddEmployeeButton.tsxをコンポーネントを追加し、入力・選択項目の整備
APIリクエスト・バリデーション・エラーハンドリングの強化

補足
現在、DynamoDBがないため社員登録をしても登録されません。
AWS導入時に、DynamoDBに保存できるようにすることを想定しています。

AIの利用
フォームやボタンの新規作成時に元になるものを生成させました。