### PR TITLE
Task

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,7 +6,13 @@ import { Button, Box, Typography } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ProjectForm from "../components/ProjectForm";
 import { Employee } from "../models/Employee";
+import { pageMetadata } from "../../lib/metadata";
+import { Metadata } from "next";
 
+export const metadata: Metadata = {
+  title: pageMetadata.home.title,
+  description: pageMetadata.home.description,
+};
 export default function Home() {
   const [showProjectForm, setShowProjectForm] = useState(false);
   const [selectedEmployees, setSelectedEmployees] = useState<Employee[]>([]);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,17 +1,69 @@
+"use client";
+import { useState, useCallback, useEffect } from "react";
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
-import { Metadata } from "next";
-import { pageMetadata } from "../../lib/metadata";
-
-export const metadata: Metadata = {
-  title: pageMetadata.home.title,
-  description: pageMetadata.home.description,
-};
+import { Button, Box, Typography } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import ProjectForm from "../components/ProjectForm";
+import { Employee } from "../models/Employee";
 
 export default function Home() {
+  const [showProjectForm, setShowProjectForm] = useState(false);
+  const [selectedEmployees, setSelectedEmployees] = useState<Employee[]>([]);
+
+  const handleOpenProjectForm = () => {
+    setShowProjectForm(true);
+  };
+
+  const handleCloseProjectForm = () => {
+    setShowProjectForm(false);
+  };
+
+  const handleSelectedEmployeesChange = useCallback((employees: Employee[]) => {
+    setSelectedEmployees(employees);
+  }, []);
+
+  const handleResetSelection = useCallback(() => {
+    setSelectedEmployees([]);
+  }, []);
+
+  // 選択された社員が1人以上になった時に自動でプロジェクトフォームを開く
+  useEffect(() => {
+    if (selectedEmployees.length > 0 && !showProjectForm) {
+      setShowProjectForm(true);
+    }
+  }, [selectedEmployees, showProjectForm]);
+
   return (
     <GlobalContainer>
-      <SearchEmployees />
+      <Box sx={{ position: "relative" }}>
+        <Typography variant="body1" textAlign="center" color="text.secondary" mb={2}>
+          社員を選択するか、プロジェクトを立案ボタンをクリックして、下側にフォームを表示できます
+        </Typography>
+        
+        <Box sx={{ display: "flex", justifyContent: "center", mb: 3 }}>
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={<AddIcon />}
+            onClick={handleOpenProjectForm}
+            sx={{ minWidth: 200 }}
+          >
+            プロジェクトを立案
+          </Button>
+        </Box>
+        
+        {showProjectForm && (
+          <Box sx={{ mb: 3 }}>
+            <ProjectForm onClose={handleCloseProjectForm} selectedEmployees={selectedEmployees} onResetSelection={handleResetSelection} />
+          </Box>
+        )}
+        
+        <SearchEmployees 
+          onSelectedEmployeesChange={handleSelectedEmployeesChange} 
+          onResetSelection={handleResetSelection}
+        />
+      </Box>
     </GlobalContainer>
   );
 }

--- a/frontend/src/components/EmployeeListContainer.tsx
+++ b/frontend/src/components/EmployeeListContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 import * as t from "io-ts";
 import { isLeft } from "fp-ts/Either";
@@ -8,6 +8,8 @@ import { Employee, EmployeeT } from "../models/Employee";
 
 export type EmployeesContainerProps = {
   filterText: string;
+  onSelectedEmployeesChange?: (selectedEmployees: Employee[]) => void;
+  onResetSelection?: () => void;
 };
 
 const EmployeesT = t.array(EmployeeT);
@@ -25,20 +27,63 @@ const employeesFetcher = async (url: string): Promise<Employee[]> => {
   return decoded.right;
 };
 
-export function EmployeeListContainer({ filterText }: EmployeesContainerProps) {
+export function EmployeeListContainer({ filterText, onSelectedEmployeesChange, onResetSelection }: EmployeesContainerProps) {
+  const [selectedEmployees, setSelectedEmployees] = useState<Set<string>>(new Set());
+  
   const encodedFilterText = encodeURIComponent(filterText);
   const { data, error, isLoading } = useSWR<Employee[], Error>(
     `/api/employees?filterText=${encodedFilterText}`,
     employeesFetcher
   );
+
   useEffect(() => {
     if (error != null) {
       console.error(`Failed to fetch employees filtered by filterText`, error);
     }
   }, [error, filterText]);
+
+  // 選択された社員の情報を親コンポーネントに送信
+  useEffect(() => {
+    if (data && onSelectedEmployeesChange) {
+      const selected = data.filter(employee => selectedEmployees.has(employee.id));
+      onSelectedEmployeesChange(selected);
+    }
+  }, [data, selectedEmployees, onSelectedEmployeesChange]);
+
+  const handleEmployeeCheck = (employeeId: string, checked: boolean) => {
+    setSelectedEmployees(prev => {
+      const newSet = new Set(prev);
+      if (checked) {
+        newSet.add(employeeId);
+      } else {
+        newSet.delete(employeeId);
+      }
+      return newSet;
+    });
+  };
+
+  // 外部からリセットされた場合の処理
+  useEffect(() => {
+    if (onResetSelection) {
+      const resetHandler = () => {
+        setSelectedEmployees(new Set());
+      };
+      // グローバルイベントリスナーとして登録（簡易実装）
+      window.addEventListener('reset-selection', resetHandler);
+      return () => {
+        window.removeEventListener('reset-selection', resetHandler);
+      };
+    }
+  }, [onResetSelection]);
+
   if (data != null) {
     return data.map((employee) => (
-      <EmployeeListItem employee={employee} key={employee.id} />
+      <EmployeeListItem 
+        employee={employee} 
+        key={employee.id}
+        checked={selectedEmployees.has(employee.id)}
+        onCheckChange={handleEmployeeCheck}
+      />
     ));
   }
   if (isLoading) {

--- a/frontend/src/components/EmployeeListItem.tsx
+++ b/frontend/src/components/EmployeeListItem.tsx
@@ -2,15 +2,21 @@ import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, Box, Card, CardContent, Typography, Chip, Checkbox } from "@mui/material";
 import { Employee } from "../models/Employee";
 import Link from "next/link";
-import { useState } from "react";
 
 export type EmployeeListItemProps = {
   employee: Employee;
+  checked?: boolean;
+  onCheckChange?: (employeeId: string, checked: boolean) => void;
 };
 
 export function EmployeeListItem(prop: EmployeeListItemProps) {
-  const [checked, setChecked] = useState(false);
-  const employee = prop.employee;
+  const { employee, checked = false, onCheckChange } = prop;
+
+  const handleCheckChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (onCheckChange) {
+      onCheckChange(employee.id, event.target.checked);
+    }
+  };
 
   return (
     <Card
@@ -73,7 +79,7 @@ export function EmployeeListItem(prop: EmployeeListItemProps) {
           {/* 右：チェックボックス */}
           <Checkbox
             checked={checked}
-            onChange={() => setChecked(!checked)}
+            onChange={handleCheckChange}
             color="primary"
           />
         </Box>

--- a/frontend/src/components/ProjectForm.tsx
+++ b/frontend/src/components/ProjectForm.tsx
@@ -1,0 +1,230 @@
+"use client";
+import { useState, ChangeEvent, FormEvent, useEffect } from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  Typography,
+  Chip,
+  Alert,
+  Snackbar,
+  IconButton,
+  Paper
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { Employee } from "../models/Employee";
+
+interface ProjectForm {
+  name: string;
+  description: string;
+  teamMembers: string[];
+}
+
+interface ProjectFormProps {
+  onClose: () => void;
+  selectedEmployees?: Employee[];
+  onResetSelection?: () => void;
+}
+
+export default function ProjectForm({ onClose, selectedEmployees = [], onResetSelection }: ProjectFormProps) {
+  const [form, setForm] = useState<ProjectForm>({
+    name: "",
+    description: "",
+    teamMembers: [],
+  });
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: "success" | "error";
+  }>({
+    open: false,
+    message: "",
+    severity: "success",
+  });
+
+  // 選択された社員が変更されたら、チームメンバーに自動追加
+  useEffect(() => {
+    const employeeNames = selectedEmployees.map(emp => emp.name);
+    setForm(prev => ({
+      ...prev,
+      teamMembers: employeeNames
+    }));
+  }, [selectedEmployees]);
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const resetForm = () => {
+    setForm({
+      name: "",
+      description: "",
+      teamMembers: [],
+    });
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      // プロジェクトデータを準備
+      const projectData = {
+        ...form,
+        teamMembers: form.teamMembers.filter(member => member.trim() !== ""),
+      };
+
+      console.log("プロジェクトデータ:", projectData);
+      
+      // 成功時の処理
+      setSnackbar({
+        open: true,
+        message: "プロジェクトを正常に立案しました！",
+        severity: "success",
+      });
+      resetForm();
+      
+      // 選択状態もリセット
+      if (onResetSelection) {
+        onResetSelection();
+      }
+      
+      // グローバルリセットイベントを発火
+      window.dispatchEvent(new CustomEvent('reset-selection'));
+      
+      // 少し遅延してからフォームを閉じる
+      setTimeout(() => {
+        onClose();
+      }, 1500);
+      
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: `エラーが発生しました: ${error instanceof Error ? error.message : "不明なエラー"}`,
+        severity: "error",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCloseSnackbar = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  return (
+    <>
+      <Paper 
+        sx={{ 
+          width: "100%", 
+          p: 3, 
+          overflowY: "auto",
+          mb: 2
+        }}
+      >
+        <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+          <Typography 
+          variant="h5" 
+          fontWeight="bold"
+          sx={{
+            textAlign: "center",
+            width: "100%"
+          }}
+          >
+            プロジェクト立案
+          </Typography>
+          <IconButton onClick={onClose} size="small">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        {selectedEmployees.length > 0 && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {selectedEmployees.length}名の社員が選択されました
+          </Alert>
+        )}
+        
+        <Box component="form" display="flex" flexDirection="column" gap={2} onSubmit={handleSubmit}>
+          <TextField
+            label="プロジェクト名"
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            required
+            fullWidth
+          />
+          
+          <TextField
+            label="プロジェクト概要"
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            multiline
+            rows={3}
+            fullWidth
+          />
+          
+          <Box>
+            <Typography variant="subtitle2" mb={1}>
+              チームメンバー
+            </Typography>
+            <Box display="flex" flexWrap="wrap" gap={0.5}>
+              {form.teamMembers.map((member) => (
+                <Chip key={member} label={member} size="small" color="primary" />
+              ))}
+              {form.teamMembers.length === 0 && (
+                <Typography variant="body2" color="text.secondary">
+                  選択された社員がここに表示されます
+                </Typography>
+              )}
+            </Box>
+          </Box>
+          
+          <Box display="flex" gap={2} justifyContent="center" mt={2}>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              size="large"
+              disabled={isSubmitting}
+              sx={{ minWidth: 120 }}
+            >
+              {isSubmitting ? "立案中..." : "立案"}
+            </Button>
+            
+            <Button
+              type="button"
+              variant="outlined"
+              size="large"
+              onClick={resetForm}
+              disabled={isSubmitting}
+              sx={{ minWidth: 120 }}
+            >
+              リセット
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          sx={{ width: "100%" }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+} 

--- a/frontend/src/components/SearchEmployees.tsx
+++ b/frontend/src/components/SearchEmployees.tsx
@@ -2,9 +2,16 @@
 import { Paper, TextField } from "@mui/material";
 import { useState } from "react";
 import { EmployeeListContainer } from "./EmployeeListContainer";
+import { Employee } from "../models/Employee";
 
-export function SearchEmployees() {
+export type SearchEmployeesProps = {
+  onSelectedEmployeesChange?: (selectedEmployees: Employee[]) => void;
+  onResetSelection?: () => void;
+};
+
+export function SearchEmployees({ onSelectedEmployeesChange, onResetSelection }: SearchEmployeesProps) {
   const [searchKeyword, setSearchKeyword] = useState("");
+  
   return (
     <Paper
       sx={{
@@ -23,6 +30,8 @@ export function SearchEmployees() {
       <EmployeeListContainer
         key="employeesContainer"
         filterText={searchKeyword}
+        onSelectedEmployeesChange={onSelectedEmployeesChange}
+        onResetSelection={onResetSelection}
       />
     </Paper>
   );


### PR DESCRIPTION
概要
プロジェクト立案機能を追加し、社員選択時にフォームを表示できるようにした。
社員リストにチェックボックスを導入し、選択した社員をプロジェクトのメンバーに追加できるようにした。

詳細
プロジェクト立案をボタンを押すまたは社員リストにチェックをつけることでプロジェクト立案フォームを表示できるようにした。そのフォームではプロジェクト名、概要の記入、メンバーの追加を行うことでき、「ボタン」を押すことで立案できる設計にした。

生成AIの利用
立案やフォームを閉じるときに社員の選択を解除する設計の際に使用した。